### PR TITLE
clear "greater than, "less than" and duplicated whitespaces

### DIFF
--- a/apps/tasks/src/create-task/format-branch-name.ts
+++ b/apps/tasks/src/create-task/format-branch-name.ts
@@ -6,11 +6,14 @@ const clearName = (name: string): string =>
     .replace(/\+\s/, '')
     .replace(/-\s/, '')
     .replace(/\./, '')
-    .replace(/\s/g, '-')
+    .replace(/>/g, '')
+    .replace(/</g, '')
     .replace(/:/g, '')
     .replace(/"/g, '')
     .replace(/&/g, '')
     .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s/g, '-')
     .toLowerCase()
 
 const getTypeTask = (type: string): string => {


### PR DESCRIPTION
Cambios en la limpieza del nombre de la rama:
- Limpiar caracteres de mayor y menor que
- Eliminar duplicidad de espacios en blanco provocada por la propia limpieza de caracteres especiales
- Dejar para el final la sustitución de espacios por guiones